### PR TITLE
Fix mapping error codes and Mongo settings

### DIFF
--- a/backend/src/Ca.Application/Modules/Auth/AuthMapper.cs
+++ b/backend/src/Ca.Application/Modules/Auth/AuthMapper.cs
@@ -22,11 +22,11 @@ public static class AuthMapper
             {
                 AuthCreationResult.EmailAlreadyExists => new OperationResult<RegisterResponse>(
                     false,
-                    Error: new CustomError(ResultErrorCode.IsEmailAlreadyConfirmed, "User already exists.")
+                    Error: new CustomError(ResultErrorCode.IsEmailTaken, "User already exists.")
                 ),
                 _ => new OperationResult<RegisterResponse>(
                     false,
-                    Error: new CustomError(ResultErrorCode.IsEmailAlreadyConfirmed, "Creation failed.")
+                    Error: new CustomError(ResultErrorCode.NetIdentityFailed, "Creation failed.")
                 )
             };
 }

--- a/backend/src/Ca.Infrastructure/Persistence/Mongo/ServiceExtensionsMongo.cs
+++ b/backend/src/Ca.Infrastructure/Persistence/Mongo/ServiceExtensionsMongo.cs
@@ -17,7 +17,7 @@ public static class ServiceExtensionsMongo
                                         ?? throw new InvalidOperationException("MongoDB ConnectionString is missing.");
 
             settings.DatabaseName = config["MyMongoDbSettings:DatabaseName"]
-                                    ?? throw new InvalidOperationException("MongoDB DatabaseName is missing.");;
+                                    ?? throw new InvalidOperationException("MongoDB DatabaseName is missing.");
         });
         
         // 2. Register as IMyMongoDbSettings


### PR DESCRIPTION
## Summary
- return proper error codes in auth mapping
- fix MongoDB settings configuration typo

## Testing
- `dotnet test backend/src/ca-template.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684403b39bd48327ae8b684a784450c6